### PR TITLE
Fixing Gigasecond example.

### DIFF
--- a/gigasecond/example.lisp
+++ b/gigasecond/example.lisp
@@ -8,7 +8,9 @@
   (reverse
    (subseq
     (multiple-value-list
-     (decode-universal-time
-      (+ (encode-universal-time second minute hour day month year)
-	 (expt 10 9))))
+     (let ((TZ 0))
+       (decode-universal-time
+        (+ (encode-universal-time second minute hour day month year TZ)
+           (expt 10 9))
+        TZ)))
     0 6)))

--- a/gigasecond/gigasecond-test.lisp
+++ b/gigasecond/gigasecond-test.lisp
@@ -11,13 +11,13 @@
   (assert-equal '(1931 9 10 1 46 40) (gigasecond:from 1900 1 1 0 0 0)))
 
 (define-test from-unix-epoch
-  (assert-equal '(2001 9 9 2 46 40) (gigasecond:from 1970 1 1 0 0 0)))
+  (assert-equal '(2001 9 9 1 46 40) (gigasecond:from 1970 1 1 0 0 0)))
 
 (define-test from-20110425T120000Z
-  (assert-equal '(2043 1 1 12 46 40) (gigasecond:from 2011 4 25 12 0 0)))
+  (assert-equal '(2043 1 1 13 46 40) (gigasecond:from 2011 4 25 12 0 0)))
 
 (define-test from-19770613T235959Z
-  (assert-equal '(2009 2 20 0 46 39) (gigasecond:from 1977 6 13 23 59 59)))
+  (assert-equal '(2009 2 20 1 46 39) (gigasecond:from 1977 6 13 23 59 59)))
 
 (define-test from-19590719T123030Z
   (assert-equal '(1991 3 27 14 17 10) (gigasecond:from 1959 7 19 12 30 30)))


### PR DESCRIPTION
The example code was wrong because it did not take into consideration
the timezone at all. Once it did that it brought to light that other
tests were incorrect.