### PR TITLE
xlisp #26: setup xlisp-test and cl-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,33 @@
-language: bash
+language: lisp
+
+env:
+    matrix:
+      # - LISP=abcl
+      # - LISP=allegro
+      - LISP=sbcl
+      - LISP=sbcl32
+      - LISP=ccl
+      - LISP=ccl32
+      - LISP=clisp
+      - LISP=clisp32
+      # - LISP=cmucl
+      - LISP=ecl
+
+matrix:
+  allow_failures:
+    # - env: LISP=abcl
+    # - env: LISP=allegro
+    - env: LISP=ccl
+    - env: LISP=ccl32
+    - env: LISP=clisp
+    - env: LISP=clisp32
+    # - env: LISP=cmucl
+    - env: LISP=ecl
+
+install:
+  - curl -L https://github.com/luismbo/cl-travis/raw/master/install.sh | sh
 
 script:
   - bin/fetch-configlet
   - bin/configlet .
+  - cl -l 'lisp-unit' -f 'bin/xlisp-test.lisp' -e '(when (xlisp-test:run-tests-all) (uiop:quit 4))'

--- a/anagram/anagram-test.lisp
+++ b/anagram/anagram-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:anagram-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "anagram")
+#-xlisp-test (load "anagram")
 
 (in-package #:anagram-test)
 
@@ -45,6 +45,7 @@
   (assert-equal '()
       (anagram:anagrams-for "banana" '("banana"))))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :anagram-test))

--- a/beer-song/beer-song-test.lisp
+++ b/beer-song/beer-song-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:beer-song-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "beer")
+#-xlisp-test (load "beer")
 
 (in-package #:beer-song-test)
 
@@ -59,6 +59,7 @@ Go to the store and buy some more, 99 bottles of beer on the wall.
   (assert-equal +song-8-6+ (beer:sing 8 6))
   (assert-equal +song-3-0+ (beer:sing 3)))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :beer-song-test))

--- a/bin/xlisp-test.lisp
+++ b/bin/xlisp-test.lisp
@@ -1,0 +1,160 @@
+(defpackage #:xlisp-test
+  (:use #:cl #:lisp-unit)
+  (:export #:run-tests-all
+	   #:excluded-pathname-p
+	   #:example-packages-p
+	   #:test-packages-p
+	   #:problems-p))
+
+(in-package #:xlisp-test)
+
+;;; Optional messaging
+
+(defparameter *verbosity* nil
+  "Verbosity of feedback.
+
+- 1 :: warn
+- 2 :: info
+- 4 :: debug")
+
+(defun verbosity-p (level)
+  (check-type level integer)
+  (not (zerop (logand level *verbosity*))))
+
+(defun notice (level datum &rest arguments)
+  (when (verbosity-p level)
+    (format t datum (values-list arguments))))
+
+(defun alert (message)
+  (notice 1 "ALERT: ~A" message))
+
+(defun inform (message)
+  (notice 2 "INFO: ~A" message))
+
+
+;;; Managing paths and packages
+
+(defparameter *excluded-paths* '("bin" "docs")
+  "Pathnames in xlisp to exclude from test search")
+
+(defun excluded-pathname-p (pathname)
+  "Identify an excluded pathname."
+  (let ((exclusions (map 'list
+			 (lambda (path)
+			   (truename (make-pathname :directory (list :relative path))))
+			 *excluded-paths*)))
+    (find (truename pathname) exclusions :test #'pathname-match-p)))
+
+(defun list-test-files (name)
+  "List files matching `name' in non-excluded subdirectories."
+  (if (wild-pathname-p name)
+      (setf name (pathname name))
+      (setf name (make-pathname :name name :type "lisp")))
+  (remove-if #'excluded-pathname-p
+	     (directory (merge-pathnames
+			 name
+			 (make-pathname :directory '(:relative :wild))))
+	     :key #'directory-namestring))
+
+
+;;; Load example exercises
+
+(defparameter *example-files*
+  (list-test-files "example")
+  "All example files.")
+
+(defparameter *example-packages*
+  ()
+  "All example packages")
+
+(defun example-packages-p ()
+  "What, if any, example packages have been defined?"
+  *example-packages*)
+
+(defun load-examples ()
+  "Load example files, record new packages in `*example-packages'."
+  (inform "Loading examples...")
+  (let ((packages-before (list-all-packages)))
+    (dolist (file *example-files*)
+      (load file :verbose (verbosity-p 2) :print (verbosity-p 2)))
+    (setf *example-packages*
+	  (set-difference (list-all-packages) packages-before))))
+
+
+;;; Load exercise tests, record packages
+
+(defparameter *test-packages*
+  ()
+  "List of test packages.")
+
+(defun test-packages-p ()
+  "What, if any, test packages are defined?"
+  *test-packages*)
+
+(defparameter *test-files*
+  (list-test-files (pathname "*-test.lisp"))
+  ;; Hack to get SBCL (possibly others) to interpret wildcard
+  ;; filenames as they would.
+  "All test files.")
+
+(defun load-test-files ()
+  "Load test files, record new packages in `*test-packages*'."
+  (pushnew :xlisp-test *features*)
+  (inform "Loading test files...")
+  (let ((packages-before (list-all-packages)))
+    (dolist (file *test-files*)
+      (load file :verbose t :print t))
+    (setf *test-packages*
+	  (set-difference (list-all-packages) packages-before))))
+
+
+;;; Define collection of problematic test results
+
+(defparameter *problems*
+  ()
+  "Record of failed or errored test results")
+
+(defun problems-p ()
+  "What tests were problematic, if any?"
+  *problems*)
+
+(defun record-problem (result)
+  "Record problem test result."
+  (alert "Recording problem")
+  (pushnew result *problems*))
+
+(defun delete-all-problems ()
+  "Clear all problem test results."
+  (inform "Deleting problems...")
+  (setf *problems* ()))
+
+
+;;; Define lisp-unit test handling
+
+(defun handle-results (results)
+  "Handle lisp-unit's test-run-complete signal."
+  (when (failed-tests results)
+    (print-failures results)
+    (record-problem results))
+  (when (error-tests results)
+    (print-errors results)
+    (record-problem results)))
+
+
+;;; Define test runner
+
+(defun run-tests-all (&optional (verbosity 2))
+  "Run all tests."
+  (setf *verbosity* verbosity)
+  (inform (format nil "Verbosity level: ~D" *verbosity*))
+  (inform "Running all xlisp tests...")
+  (or *example-packages* (load-examples))
+  (or *test-packages* (load-test-files))
+  (and (problems-p) (delete-all-problems))
+  (dolist (package *test-packages* (problems-p))
+    (handler-bind ((test-run-complete
+		    (lambda (condition)
+		      (handle-results (results condition)))))
+      (signal-results)
+      (inform (format nil "Running tests in ~S" package))
+      (run-tests :all package))))

--- a/binary/binary-test.lisp
+++ b/binary/binary-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:binary-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "binary")
+#-xlisp-test (load "binary")
 
 (in-package #:binary-test)
 
@@ -31,6 +31,7 @@
 (define-test invalid-binary-is-decimal-0
   (assert-equal 0 (binary:to-decimal "carrot")))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all))

--- a/bob/bob-test.lisp
+++ b/bob/bob-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:bob-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "bob")
+#-xlisp-test (load "bob")
 
 (in-package #:bob-test)
 
@@ -49,6 +49,7 @@
 (define-test responds-to-number-question
   (assert-equal "Sure." (bob:response-for "4?")))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all))

--- a/difference-of-squares/difference-of-squares-test.lisp
+++ b/difference-of-squares/difference-of-squares-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:squares-test
   (:use #:cl #:lisp-unit))
 
-(load "squares")
+#-xlisp-test (load "squares")
 
 (in-package #:squares-test)
 
@@ -28,6 +28,7 @@
 (define-test difference-of-sums-to-100
   (assert-equal 25164150 (squares:difference 100)))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :squares-test))

--- a/etl/etl-test.lisp
+++ b/etl/etl-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:etl-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "etl")
+#-xlisp-test (load "etl")
 
 (in-package #:etl-test)
 
@@ -49,6 +49,7 @@
     (assert-equalp (make-hash expected-output)
 	(etl:transform (make-hash input-data)))))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :etl-test))

--- a/gigasecond/gigasecond-test.lisp
+++ b/gigasecond/gigasecond-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:gigasecond-test
   (:use #:cl #:lisp-unit))
 
-(load "gigasecond")
+#-xlisp-test (load "gigasecond")
 
 (in-package #:gigasecond-test)
 
@@ -26,6 +26,7 @@
 ; (define-test your-birthday
 ;   (assert-equal '(year2 month2 day2) (gigasecond:from year1 month1 day1)))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :gigasecond-test))

--- a/grade-school/grade-school-test.lisp
+++ b/grade-school/grade-school-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:grade-school-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "school")
+#-xlisp-test (load "school")
 
 (in-package #:grade-school-test)
 
@@ -58,6 +58,7 @@
                      (:grade 6 :students ("Kareem")))
                    (school:sorted school))))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :grade-school-test))

--- a/grains/grains-test.lisp
+++ b/grains/grains-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:grains-test
   (:use #:cl #:lisp-unit))
 
-(load "grains")
+#-xlisp-test (load "grains")
 
 (in-package #:grains-test)
 
@@ -31,6 +31,7 @@
 (define-test total-grains
   (assert-equal 18446744073709551615  (grains:total)))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :grains-test))

--- a/leap/leap-test.lisp
+++ b/leap/leap-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:leap-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "leap-year")
+#-xlisp-test (load "leap-year")
 
 (in-package #:leap-test)
 
@@ -22,6 +22,7 @@
 (define-test exceptional-century
   (assert-true (leap:leap-year-p 2400)))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :leap-test))

--- a/meetup/meetup-test.lisp
+++ b/meetup/meetup-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:meetup-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "meetup")
+#-xlisp-test (load "meetup")
 
 (in-package #:meetup-test)
 
@@ -231,6 +231,7 @@
 (define-test last-sunday-of-april-2013
   (assert-equal '(2013 4 28) (meetup:meetup 4 2013 :sunday :last)))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :meetup-test))

--- a/nucleotide-count/nucleotide-count-test.lisp
+++ b/nucleotide-count/nucleotide-count-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:nucleotide-count-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "dna")
+#-xlisp-test (load "dna")
 
 (in-package #:nucleotide-count-test)
 
@@ -38,6 +38,7 @@
       (dna:nucleotide-counts
        "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC")))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :nucleotide-count-test))

--- a/phone-number/phone-number-test.lisp
+++ b/phone-number/phone-number-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:phone-number-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "phone")
+#-xlisp-test (load "phone")
 
 (in-package #:phone-number-test)
 
@@ -31,6 +31,7 @@
 (define-test pretty-print-with-full-us-phone-number
   (assert-equal "(123) 456-7890" (phone:pretty-print "11234567890")))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :phone-number-test))

--- a/point-mutations/point-mutations-test.lisp
+++ b/point-mutations/point-mutations-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:point-mutations-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "dna")
+#-xlisp-test (load "dna")
 
 (in-package #:point-mutations-test)
 
@@ -27,6 +27,7 @@
   (assert-equal nil (dna:hamming-distance "AGACAACAGCCAGCCGCCGGATT" "AGACATCTTTCAGCCGCCGGATTAGGCAA"))
   (assert-equal nil (dna:hamming-distance "AGG" "AGACAACAGCCAGCCGCCGGATT")))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :point-mutations-test))

--- a/rna-transcription/rna-transcription-test.lisp
+++ b/rna-transcription/rna-transcription-test.lisp
@@ -3,7 +3,7 @@
 (defpackage :rna-transcription-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "dna")
+#-xlisp-test (load "dna")
 
 (in-package #:rna-transcription-test)
 
@@ -25,6 +25,7 @@
 (define-test it-validates-dna-strands
   (assert-error 'error (dna:to-rna "XCGFGGTDTTAA")))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :rna-transcription-test))

--- a/robot-name/example.lisp
+++ b/robot-name/example.lisp
@@ -1,13 +1,8 @@
 (defpackage #:robot
   (:use #:common-lisp)
-  (:export #:build-robot #:robot-name #:reset-name))
+  (:export #:build-robot #:robot-name #:reset-name #:robot))
 
 (in-package #:robot)
-
-;;; useful for debugging
-(defmethod print-object ((object robot) stream)
-  (print-unreadable-object (object stream :type t)
-    (write (robot-name object) :stream stream)))
 
 (defun random-alpha-char ()
   (code-char (+ (char-code #\A) (random 26))))
@@ -26,3 +21,8 @@
   ((name :reader robot-name :initform (random-robot-name))))
 (defun reset-name (robot)
   (setf (slot-value robot 'name) (random-robot-name)))
+
+;;; useful for debugging
+(defmethod print-object ((object robot) stream)
+  (print-unreadable-object (object stream :type t)
+    (write (robot-name object) :stream stream)))

--- a/robot-name/robot-name-test.lisp
+++ b/robot-name/robot-name-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:robot-name-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "robot")
+#-xlisp-test (load "robot")
 
 (in-package #:robot-name-test)
 
@@ -35,6 +35,7 @@
 	(robot:robot-name robot)
 	original-name)))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :robot-name-test))

--- a/roman-numerals/roman-numerals-test.lisp
+++ b/roman-numerals/roman-numerals-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:roman-test
   (:use #:cl #:lisp-unit))
 
-(load "roman")
+#-xlisp-test (load "roman")
 
 (in-package #:roman-test)
 
@@ -61,6 +61,7 @@
 (define-test test-3000
   (assert-equal "MMM" (roman:romanize 3000)))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :roman-test))

--- a/scrabble-score/scrabble-score-test.lisp
+++ b/scrabble-score/scrabble-score-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:scrabble-score-test
   (:use #:cl #:lisp-unit))
 
-(load "scrabble-score")
+#-xlisp-test (load "scrabble-score")
 
 (in-package #:scrabble-score-test)
 
@@ -32,6 +32,7 @@
 (define-test scores-a-very-long-word
   (assert-equal 27 (scrabble-score:score-word "UNEXCLUSIVENESS")))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :scrabble-score-test))

--- a/space-age/space-age-test.lisp
+++ b/space-age/space-age-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:space-age-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "space-age")
+#-xlisp-test (load "space-age")
 
 (in-package #:space-age-test)
 
@@ -50,6 +50,7 @@
     (rounds-to 260.16 (space-age:on-earth seconds))
     (rounds-to 1.58 (space-age:on-neptune seconds))))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :space-age-test))

--- a/triangle/triangle-test.lisp
+++ b/triangle/triangle-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:triangle-test
   (:use #:cl #:lisp-unit))
 
-(load "triangle")
+#-xlisp-test (load "triangle")
 
 (in-package #:triangle-test)
 
@@ -22,6 +22,7 @@
 (define-test invalid-2
   (assert-equal  :illogical (triangle:triangle 1 2 1)))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :triangle-test))

--- a/word-count/word-count-test.lisp
+++ b/word-count/word-count-test.lisp
@@ -3,7 +3,7 @@
 (defpackage #:word-count-test
   (:use #:common-lisp #:lisp-unit))
 
-(load "word-count")
+#-xlisp-test (load "word-count")
 
 (in-package #:word-count-test)
 
@@ -41,6 +41,7 @@
   (assert-assoc-equal '(("go" . 3) ("on" . 3))
 	  (phrase:word-count "go ON Go On GO on")))
 
+#-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))
   (run-tests :all :word-count-test))


### PR DESCRIPTION
- setup bin/xlisp-test
- setup tests with xlisp-test feature
- setup .travis.yml
- extensive testing
- move robot print-object for specs
- allow failures on non-SBCL implementations for the time being