### PR TITLE
Foregoing bank-account exercise.

### DIFF
--- a/config.json
+++ b/config.json
@@ -39,6 +39,7 @@
     "docs"
   ],
   "foregone": [
-    "accumulate"
+      "accumulate",
+      "bank-account"
   ]
 }


### PR DESCRIPTION
The exercise specifically talks about threads which cannot be done in
an implementation independant fashion in Common Lisp. Removing that
from the exercise does not leave much of interest that has not been
seen already.