### PR TITLE
Fixed gigasecond:from argument list

### DIFF
--- a/gigasecond/gigasecond.lisp
+++ b/gigasecond/gigasecond.lisp
@@ -4,4 +4,4 @@
   (:export #:from))
 (in-package #:gigasecond)
 
-(defun from (year month day))
+(defun from (year month day hour minute second))


### PR DESCRIPTION
Tests for ```gigasecond:from``` pass 6 arguments not 3.