### PR TITLE
Get off the legacy platform on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: lisp
 
+sudo: false
+
 env:
     matrix:
       - LISP=sbcl


### PR DESCRIPTION
We don't need sudo, so we should be able to use the containerized build infrastructure.