### PR TITLE
Deprecate help.exercism.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Exercism exercises in Lisp
 ## Contributing To the Common Lisp Track
 
 ### Contributing Guide
- 
+
 Please be familiar with the
 [contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data)
 in the x-api repository. This describes how all the language tracks
@@ -26,11 +26,9 @@ that fail tests
 
 ### Development setup
 
-Direct contributions to the Common Lisp code in xLisp are always
-welcome. 
-Refer to
-[the Getting Started Guide](http://help.exercism.io/getting-started-with-lisp.html)
-for the Common Lisp track to get your environment set up if needed.
+Direct contributions to the Common Lisp code in xLisp are always welcome.
+Refer to [the Getting Started Guide](http://exercism.io/languages/lisp) for the
+Common Lisp track to get your environment set up if needed.
 
 New exercises or changes to existing ones can be submitted via a pull
 request. You will need a GitHub account and you will need to fork
@@ -54,7 +52,7 @@ submitting the changes.
 A contributor will need to install
 [CIM](https://github.com/KeenS/CIM),
 [QuickLisp](https://www.quicklisp.org/beta/), and a few Lisp
-implementations. 
+implementations.
 
 ###### CIM
 
@@ -75,7 +73,7 @@ multi-implementation installation and upgrade system.
 
 It is beyond the scope of this document to describe how to install
 different Lisp implementations. Please find those instructions on
-those implementations' websites. 
+those implementations' websites.
 
 After installing Lisp implementations. Check that CIM can see them by
 running `cim list use`. This should list the implementation names
@@ -91,7 +89,7 @@ for i in `cim list use`; do cim use $i; done
 Instructions to install QuickLisp can be found on this
 [website](https://www.quicklisp.org/beta/#installation). Following
 these instructions will install the QuickLisp system into
-`~/.quicklisp`. 
+`~/.quicklisp`.
 
 To ensure CIM and all your implementations know and use QuickLisp you
 can run the following commands:
@@ -123,7 +121,7 @@ implementations. To run the build yourself on your implementation load
 
 If CIM is installed then running all the tests for one implementation
 can be done with (this will return with a non-zero error code if there
-are problems): 
+are problems):
 
 	cl -f bin/xlisp-test.lisp -e '(xlisp-test:travis-build)'
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,10 +1,8 @@
 ## Setup
 
-Check out
-[Exercism Help](http://help.exercism.io/getting-started-with-lisp.html)
-for instructions to get started writing Common Lisp. That page will
-explain how to install and setup a Lisp implementation and how to run
-the tests.
+Check out [Exercism Help](http://exercism.io/languages/lisp) for instructions to
+get started writing Common Lisp. That page will explain how to install and setup
+a Lisp implementation and how to run the tests.
 
 ## Formatting
 
@@ -45,7 +43,3 @@ order to have it set whenever Emacs is launched.
 One suggested add-on for Emacs and Common Lisp is
 [SLIME](https://github.com/slime/slime) which offers tight integration
 with the REPL; making iterative coding and testing very easy.
-
-
-
-


### PR DESCRIPTION
Replace references to `help.exercism.io` with [exercism.io/languages/lisp](http://exercism.io/languages/lisp).

Delete trailing whitespace throughout and re-wrap the lines under "Development setup" in README.md and "Setup" in SETUP.md.

Close #108