### PR TITLE
Protect quoted list from mutation

### DIFF
--- a/exercises/word-count/word-count-test.lisp
+++ b/exercises/word-count/word-count-test.lisp
@@ -12,8 +12,8 @@
   values of the items must match. But the order is not
   important. Equality is tested with equal"
   (assert-equal
-      (sort expected #'string< :key #'car)
-      (sort actual #'string< :key #'car)))
+      (sort (copy-seq expected) #'string< :key #'car)
+      (sort (copy-seq actual) #'string< :key #'car)))
 
 (define-test count-one-word
   (assert-assoc-equal '(("word" . 1))


### PR DESCRIPTION
Sort is a potentially destructive operation; this made the tests fail when run from the slime repl, yet pass when run as a side-effect of loading the file. Some head-scratching ensued :) I'm copying both sequences for symmetry and simplicity of interface.