### PR TITLE
Add word-is-not-own-anagram-case-insensitively

### DIFF
--- a/exercises/anagram/anagram-test.lisp
+++ b/exercises/anagram/anagram-test.lisp
@@ -44,6 +44,10 @@
   (assert-equal '()
       (anagram:anagrams-for "banana" '("banana"))))
 
+(define-test word-is-not-own-anagram-case-insensitively
+  (assert-equal '()
+      (anagram:anagrams-for "bananarama" '("BananaRama"))))
+
 #-xlisp-test
 (let ((*print-errors* t)
       (*print-failures* t))


### PR DESCRIPTION
My implementation of anagrams-for suffered from this bug.